### PR TITLE
Import QMainWindow from QtWidgets

### DIFF
--- a/pySAred_V1.5.1.py
+++ b/pySAred_V1.5.1.py
@@ -16,7 +16,7 @@ from scipy.interpolate import griddata
 QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
 QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)
 
-class Ui_MainWindow(QtGui.QMainWindow):
+class Ui_MainWindow(QtWidgets.QMainWindow):
 
     def __create_element(self, object, geometry, objectName, text=None, font=None, placeholder=None, visible=None, stylesheet=None, checked=None, title=None, combo=None, enabled=None):
 


### PR DESCRIPTION
Hej Alexey,

Hope you're doing well. I know you're not working at SuperAdam anymore, and PySared is probably unmaintained at the moment. However, the current code is not compatible with the latest version of Qt.

When I run the latest version, it gives me the following error both on Windows and Linux:

`AttributeError: module 'PyQt5.QtGui' has no attribute 'QMainWindow'`

Assuming the code worked before, it seems QMainWindow has been moved from QtGui to QtWidgets. The simple solution is to simply import QMainWindow from QtWidgets instead. I've tested this on my main machine (Fedora Linux) and on Windows 11 as well. Running Python 3.11 and Python 3.9 respectively if I recall correctly.

Of course the compiled binaries that exist don't need to be changed, as they work. But there's no binaries available for Linux (which is my main OS). So it would be nice to get this change included, even if it's just to make this work with Linux out of the box (as well as with Windows (and I assume MacOS) if anyone feels like opening this from the CLI instead). 

If you want to, I can fix binaries for Linux as well. But again this is probably unmaintained, and I'm guessing most people running Linux will have little trouble running this from the terminal anyway. There's no weird modules or anything used, the standard packages from the repo (or pip) work well enough. 

Cheers,
Sjoerd
